### PR TITLE
Release/v0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 #Homepage = "/"
 Documentation = "https://masterpiece93.github.io/django-gauth/"
 Repository = "https://github.com/masterPiece93/django-gauth"
-Changelog = "CHANGELOG.md"
+#Changelog = "CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
# Releasing on TestPyPI

targetted to release on TestPyPi .

* bumped version : `v0.1.0` **=>** `v0.1.1`
* commented out changelog parameter ( **~**_pyproject.toml_ ) which was causing release build failure ( ~Github Actions ).
* rectified issues in classifier section ( **~**_pyproject.toml_ ) which was causing release build failure ( ~Github Actions )..