### PR TITLE
`PR` | private attribute `_id_token` issue fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Security: the OAuth `client_secret` (and `client_id`) are no longer persisted in the
   session store. `credentials_to_dict()` omits them and `check_gauth_authentication()`
   re-injects them from settings when rebuilding `Credentials`.
+- Robustness: `callback()` now reads the public `credentials.id_token` property instead of
+  the private `credentials._id_token` attribute, avoiding breakage on future `google-auth`
+  releases.
 
 ---
 

--- a/src/django_gauth/views.py
+++ b/src/django_gauth/views.py
@@ -169,7 +169,7 @@ def callback(request: HttpRequest):  # type: ignore
     credentials = flow.credentials
     # verify token, while also retrieving information about the user
     id_info = id_token.verify_oauth2_token(
-        id_token=credentials._id_token,  # pylint: disable=protected-access
+        id_token=credentials.id_token,
         request=requests.Request(),
         audience=settings.GOOGLE_CLIENT_ID,
         clock_skew_in_seconds=5,

--- a/tests/test_coverage_boost.py
+++ b/tests/test_coverage_boost.py
@@ -736,7 +736,7 @@ class CallbackViewTest(TestCase):
         mock_credentials.client_id = settings.GOOGLE_CLIENT_ID
         mock_credentials.client_secret = settings.GOOGLE_CLIENT_SECRET
         mock_credentials.scopes = ["openid"]
-        mock_credentials._id_token = "fake_id_token"
+        mock_credentials.id_token = "fake_id_token"
         mock_flow_instance.credentials = mock_credentials
 
         # Setup mock id_token verification
@@ -764,6 +764,9 @@ class CallbackViewTest(TestCase):
         # Verify session was populated
         self.assertIn("id_info", request.session)
         self.assertIn(settings.CREDENTIALS_SESSION_KEY_NAME, request.session)
+        # ISSUE-3 regression: callback must read the public ``id_token`` property,
+        # not the private ``_id_token`` attribute.
+        self.assertEqual(mock_verify.call_args.kwargs["id_token"], "fake_id_token")
 
     @patch("django_gauth.views.id_token.verify_oauth2_token")
     @patch("django_gauth.views.Flow.from_client_config")
@@ -781,7 +784,7 @@ class CallbackViewTest(TestCase):
         mock_credentials.client_id = settings.GOOGLE_CLIENT_ID
         mock_credentials.client_secret = settings.GOOGLE_CLIENT_SECRET
         mock_credentials.scopes = ["openid", "email"]
-        mock_credentials._id_token = "id_tok"
+        mock_credentials.id_token = "id_tok"
         mock_flow_instance.credentials = mock_credentials
 
         mock_verify.return_value = {
@@ -827,7 +830,7 @@ class CallbackViewTest(TestCase):
         mock_flow_class.return_value = mock_flow_instance
         mock_credentials = MagicMock()
         mock_credentials.scopes = settings.SCOPE
-        mock_credentials._id_token = "id_tok"
+        mock_credentials.id_token = "id_tok"
         mock_flow_instance.credentials = mock_credentials
         mock_verify.return_value = {
             "email": "user@example.com",


### PR DESCRIPTION
## Issue 
- #67 

**Fix: use public credentials.id_token instead of private _id_token**

- callback() now reads the documented credentials.id_token property rather than the private credentials._id_token attribute, avoiding breakage on future google-auth upgrades. Updated callback mocks to the public name and added a regression assertion. CHANGELOG updated.